### PR TITLE
ignore RSA keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 # sensitive data
 
 *.env
+
+# nginx RSA keys
+
+nginx/keys.json


### PR DESCRIPTION
Nginx generates some RSA keys during while building the Docker stack. Updates the gitignore to keep these out of the repo