### PR TITLE
Bug/fix CORs

### DIFF
--- a/src/frontend/src/config/ApiConfig.ts
+++ b/src/frontend/src/config/ApiConfig.ts
@@ -1,5 +1,7 @@
 const ApiConfig = Object.freeze({
-    API_URL: 'https://localhost:7230/api'
+    API_HTTPS_HOST: 'https://localhost:7230',
+    API_HTTP_HOST: 'http://localhost:5230',
+    API_URL: '/api'
 });
 
 export const supaBaseURL = 'https://qhflbfdceoyhnplcpgnh.supabase.co';

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -11,11 +11,7 @@ export default defineConfig({
     },
     server: {
         proxy: {
-            '/api': {
-                target: 'https://localhost:7230',
-                changeOrigin: false,
-                rewrite: path => path.replace(/^\/api/, '')
-            }
+            '/api': 'http://localhost:5230'
         }
     }
 });

--- a/src/server/StudioManagementSystem/Startup.cs
+++ b/src/server/StudioManagementSystem/Startup.cs
@@ -28,16 +28,6 @@ public class Startup
         // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen();
-
-        if (env.IsDevelopment()) {
-            services.AddCors(options => {
-                options.AddDefaultPolicy(policy => policy
-                    .WithOrigins("http://localhost:5173")
-                    .AllowAnyHeader()
-                    .AllowAnyMethod()
-                );
-            });
-        }
     }
 
     /// <summary>
@@ -63,18 +53,17 @@ public class Startup
         if (env.IsDevelopment()) {
             app.UseSwagger()
                 .UseSwaggerUI()
-                .UseDeveloperExceptionPage()
-                .UseCors();
+                .UseDeveloperExceptionPage();
         }
         else {
             // Enable the exception handler route
             app.UseExceptionHandler("/error")
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-                .UseHsts();
+                .UseHsts()
+                .UseHttpsRedirection();
         }
 
-        app.UseHttpsRedirection();
-
+        app.UseCors();
         app.MapControllers();
     }
 }


### PR DESCRIPTION
## Issue

Our current CORs configuration was the "quick hack" solution to make the backend accept anything from our expected frontend server. This isn't optimal for several reasons. Namely, Vite will ~grab whatever server port is available~ spin a roulette wheel for a port, which is inconsistent for different machines.

## Fix

Since CORs is something we want universally (development, prod, etc.) it should be enabled for all environments.

The frontend should correctly proxy to the backend. In development mode this means avoiding HTTPS for now, as this is further config with a self-signed cert (which hasn't been done yet and adds more complexity).

In production, the frontend should continue to proxy to the backend but with HTTPS. Again, this requires cert configuration, which hasn't been done yet. So, this is purely to get the development environments functioning consistently.