### PR TITLE
Feature/migrate on deploy

### DIFF
--- a/src/frontend/src/pages/AssignStudentsToGroup/index.tsx
+++ b/src/frontend/src/pages/AssignStudentsToGroup/index.tsx
@@ -1,1 +1,1 @@
-export { default } from './AssignStudentsTogroupContainer';
+export { default } from './AssignStudentsToGroupContainer';

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -23,4 +23,5 @@ WORKDIR /app
 COPY --from=publisher /publish .
 
 ENV ASPNETCORE_ENVIRONMENT=Production
+RUN dotnet ef database update
 ENTRYPOINT dotnet StudioManagementSystem.dll

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -23,5 +23,4 @@ WORKDIR /app
 COPY --from=publisher /publish .
 
 ENV ASPNETCORE_ENVIRONMENT=Production
-RUN dotnet ef database update
 ENTRYPOINT dotnet StudioManagementSystem.dll

--- a/src/server/StudioManagementSystem.Core/StudioManagementDbMigrationContextFactory.cs
+++ b/src/server/StudioManagementSystem.Core/StudioManagementDbMigrationContextFactory.cs
@@ -22,6 +22,7 @@ public class StudioManagementDbMigrationContextFactory : IDesignTimeDbContextFac
         var configuration = new ConfigurationBuilder()
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile(AppSettingsFilePath)
+            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json", optional: true)
             .Build();
 
         var connectionString = configuration.GetConnectionString("StudioManagementDbConnection");

--- a/src/server/StudioManagementSystem.Core/StudioManagementDbMigrationContextFactory.cs
+++ b/src/server/StudioManagementSystem.Core/StudioManagementDbMigrationContextFactory.cs
@@ -4,17 +4,20 @@ using Microsoft.Extensions.Configuration;
 
 namespace StudioManagementSystem.Core;
 
-public class InMealDbMigrationContextFactory : IDesignTimeDbContextFactory<StudioManagementDbMigrationContext>
+public class StudioManagementDbMigrationContextFactory : IDesignTimeDbContextFactory<StudioManagementDbMigrationContext>
 {
     // Holds migration infrastructure settings
     private const string AppSettingsFilePath = "appsettings.json";
 
     public StudioManagementDbMigrationContext CreateDbContext(string[] args)
     {
-        Console.WriteLine("Starting migration...");
+        Console.WriteLine("created db context");
+        return new(GetDbContextOptions());
+    }
 
-        // configuration for a JSON settings file will not work without
-        // this package installed 'Microsoft.Extensions.Configuration.Json'
+    public static DbContextOptions<StudioManagementDbMigrationContext> GetDbContextOptions()
+    {
+        Console.WriteLine("Starting migrations...");
 
         var configuration = new ConfigurationBuilder()
             .SetBasePath(Directory.GetCurrentDirectory())
@@ -23,7 +26,7 @@ public class InMealDbMigrationContextFactory : IDesignTimeDbContextFactory<Studi
 
         var connectionString = configuration.GetConnectionString("StudioManagementDbConnection");
 
-        Console.WriteLine($"Attempting to run a migration using the connection settings from '{connectionString}'");
+        Console.WriteLine($"Attempting to run migrations with connection: '{connectionString}'");
 
         var majorVersion = int.Parse(configuration.GetSection("ConnectionStrings:ServerVersionMajor").Value!);
         var minorVersion = int.Parse(configuration.GetSection("ConnectionStrings:ServerVersionMinor").Value!);
@@ -34,8 +37,8 @@ public class InMealDbMigrationContextFactory : IDesignTimeDbContextFactory<Studi
         var dbContextBuilder =
             new DbContextOptionsBuilder<StudioManagementDbMigrationContext>().UseMySql(connectionString!, serverVersion);
 
-        Console.WriteLine("created db context");
+        Console.WriteLine("created db context options");
 
-        return new(dbContextBuilder.Options);
+        return dbContextBuilder.Options;
     }
 }

--- a/src/server/StudioManagementSystem.Core/StudioManagementSystem.Core.csproj
+++ b/src/server/StudioManagementSystem.Core/StudioManagementSystem.Core.csproj
@@ -31,4 +31,12 @@
       <Compile Remove="Dtos\CreateContactDto.cs" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Content Update="appsettings.Production.json">
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </Content>
+    </ItemGroup>
+
 </Project>

--- a/src/server/StudioManagementSystem.Core/appsettings.Production.json
+++ b/src/server/StudioManagementSystem.Core/appsettings.Production.json
@@ -1,0 +1,21 @@
+﻿{
+	"Logging": {
+		"LogLevel": {
+			"Default": "Warning",
+			"System": "Information",
+			"Microsoft": "Information"
+		}
+	},
+	"ConnectionStrings": {
+		"StudioManagementDbConnection": "Server=maria-db;Port=3306;Database=StudioManagementSystem;User=sms_user;Password=super_secret_password"
+	},
+	"Urls": "https://studiomanagementsystem.localtest.me:7230",
+	"Kestrel": {
+		"Certificates": {
+			"Default": {
+				"Path": "certs/cert.crt",
+				"KeyPath": "certs/key.pem"
+			}
+		}
+	}
+}

--- a/src/server/StudioManagementSystem/DependencyInjectionExtensions.cs
+++ b/src/server/StudioManagementSystem/DependencyInjectionExtensions.cs
@@ -1,5 +1,6 @@
 using Autofac;
 using Microsoft.EntityFrameworkCore;
+using StudioManagementSystem.Core;
 using StudioManagementSystem.Infrastructure;
 using StudioManagementSystem.Infrastructure.DataServices;
 
@@ -46,7 +47,9 @@ public static class EfContextRegistrationExtensions
     /// </summary>
     public static ContainerBuilder AddEfCoreDbContexts(this ContainerBuilder builder)
     {
-        return builder.AddStudioManagementSystemDbContext();
+        return builder
+            .AddStudioManagementSystemDbContext()
+            .AddStudioManagementMigrationsDbContext();
     }
 
     /// <summary>
@@ -95,6 +98,16 @@ public static class EfContextRegistrationExtensions
              .As<IStudioManagementSystemDbContextAsync>()
              .InstancePerLifetimeScope();
          
+         return builder;
+     }
+
+     private static ContainerBuilder AddStudioManagementMigrationsDbContext(this ContainerBuilder builder)
+     {
+         builder
+             .RegisterType<StudioManagementDbMigrationContext>()
+             .WithParameter("opts", StudioManagementDbMigrationContextFactory.GetDbContextOptions())
+             .InstancePerLifetimeScope();
+
          return builder;
      }
 }

--- a/src/server/StudioManagementSystem/Program.cs
+++ b/src/server/StudioManagementSystem/Program.cs
@@ -1,4 +1,6 @@
+using Microsoft.EntityFrameworkCore;
 using StudioManagementSystem;
+using StudioManagementSystem.Core;
 
 // retrieve and inject the application configuration
 var appConfig = new ConfigurationBuilder()
@@ -22,5 +24,12 @@ var app = builder.Build();
 
 // Configure the app and web request pipeline
 startup.Configure(app, builder.Environment);
+
+// development envs should run migrations manually, as needed (speeds up launch time for dev's)
+if (!builder.Environment.IsDevelopment()) {
+    using var scope = app.Services.CreateScope();
+    var migrationDbContext = scope.ServiceProvider.GetRequiredService<StudioManagementDbMigrationContext>();
+    migrationDbContext.Database.Migrate();
+}
 
 app.Run();

--- a/src/server/StudioManagementSystem/Program.cs
+++ b/src/server/StudioManagementSystem/Program.cs
@@ -25,7 +25,7 @@ var app = builder.Build();
 // Configure the app and web request pipeline
 startup.Configure(app, builder.Environment);
 
-// development envs should run migrations manually, as needed (speeds up launch time for dev's)
+// only attempt to auto-run migrations outside of development environs to speed up build-times
 if (!builder.Environment.IsDevelopment()) {
     using var scope = app.Services.CreateScope();
     var migrationDbContext = scope.ServiceProvider.GetRequiredService<StudioManagementDbMigrationContext>();


### PR DESCRIPTION
Supports deploying the Docker stack on remote servers.
* avoids installing dotnet ef tools on remote to run migrations
* fixes minor bug I forgot to commit separately

Successfully running the prod build with `docker-compose up --build` now shows some new details when it autoruns migrations,

![image](https://github.com/albert118/Studio-Management-System/assets/26985949/f0a2eb20-1044-4a7c-9a0e-e57116443060)
